### PR TITLE
Add support package

### DIFF
--- a/packages/tbd-support/index.scss
+++ b/packages/tbd-support/index.scss
@@ -1,0 +1,2 @@
+@import "./lib/color.scss";
+@import "./lib/typography.scss";

--- a/packages/tbd-support/lib/color.scss
+++ b/packages/tbd-support/lib/color.scss
@@ -1,0 +1,1 @@
+$tbd-color-text-default: #222 !default;

--- a/packages/tbd-support/lib/typography.scss
+++ b/packages/tbd-support/lib/typography.scss
@@ -1,0 +1,13 @@
+$tbd-font-sans-serif: (
+  -apple-system,
+  system-ui,
+  BlinkMacSystemFont,
+  "Segoe UI",
+  "Roboto",
+  "Helvetica",
+  "Arial",
+  sans-serif,
+) !default;
+
+$tbd-font-weight-normal: 400 !default;
+$tbd-font-weight-bold: 700 !default;

--- a/packages/tbd-support/package.json
+++ b/packages/tbd-support/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@thoughtbot/tbd-support",
+  "version": "0.0.0",
+  "license": "MIT"
+}


### PR DESCRIPTION
The purpose of this package is to provide settings, variables, mixins
and other non-rendering tooling for the system to commonly consume.

The `system-ui` font family comes from a draft of the CSS spec:
https://drafts.csswg.org/css-fonts-4/#system-ui-def

The font weight numerical mapping comes from:
https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#Common_weight_name_mapping