### PR TITLE
Add base package

### DIFF
--- a/packages/tbd-base/index.scss
+++ b/packages/tbd-base/index.scss
@@ -1,0 +1,4 @@
+@import "@thoughtbot/tbd-support/index";
+
+@import "./lib/base-layout.scss";
+@import "./lib/base-typography.scss";

--- a/packages/tbd-base/lib/base-layout.scss
+++ b/packages/tbd-base/lib/base-layout.scss
@@ -1,0 +1,13 @@
+html {
+  box-sizing: border-box;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+
+img {
+  max-width: 100%;
+}

--- a/packages/tbd-base/lib/base-typography.scss
+++ b/packages/tbd-base/lib/base-typography.scss
@@ -1,0 +1,27 @@
+html {
+  color: $tbd-color-text-default;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: $tbd-font-weight-bold;
+}
+
+a {
+  color: $tbd-color-text-link;
+  text-decoration: underline;
+  text-decoration-skip-ink: auto;
+
+  &:hover {
+    color: $tbd-color-text-link-hover;
+  }
+}
+
+b,
+strong {
+  font-weight: $tbd-font-weight-bold;
+}

--- a/packages/tbd-base/package.json
+++ b/packages/tbd-base/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@thoughtbot/tbd-base",
+  "version": "0.0.1",
+  "license": "MIT",
+  "dependencies": {
+    "@thoughtbot/tbd-support": "0.0.1"
+  }
+}

--- a/packages/tbd-support/lib/color.scss
+++ b/packages/tbd-support/lib/color.scss
@@ -1,1 +1,5 @@
+$tbd-blue: #1568c1 !default;
+
 $tbd-color-text-default: #222 !default;
+$tbd-color-text-link: $tbd-blue !default;
+$tbd-color-text-link-hover: darken($tbd-blue, 20%) !default;


### PR DESCRIPTION
This adds a tbd-base package which provides some very high-level,
common sense base element styles:

- Global `box-sizing` is reset to `border-box`
- Heading elements are set to the system's defined bold font weight
- `strong` and `b` elements are set to the system's defined bold
  font weight
- `a` elements are given a `color` of the system's defined link color,
  and an underline style to ensure accessibility
- `img` elements set to `max-width: 100%` to make them repsonsive

The tbd-support package is updated with variables to support these new
styles.

The `box-sizing` approach comes from
https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/

Except for the `box-sizing`, all other base element styles are encapsulated
within a `tbd-base` class, making all of the styles fully opt-in, in an
attempt to prevent accidental overrides and style collisions.