### PR TITLE
Add support for icons in buttons

### DIFF
--- a/packages/tbds-button/lib/button.scss
+++ b/packages/tbds-button/lib/button.scss
@@ -43,3 +43,17 @@ $_tbds-button-text-color-hover: #fff !default;
     }
   }
 }
+
+.tbds-button__icon {
+  fill: currentColor;
+  height: 1em;
+  width: 1em;
+}
+
+.tbds-button__icon--text-to-left {
+  margin-left: 0.5em;
+}
+
+.tbds-button__icon--text-to-right {
+  margin-right: 0.5em;
+}


### PR DESCRIPTION
Example usage markup would be:

```html
<a class="tbds-button" href="#">
  <svg class="tbds-button__icon tbds-button__icon--text-to-right">…</svg>

  Button Text
</a>
```

---

This is not the exact visual look-and-feel, but the icon buttons would be akin to:

![screen shot 2018-03-09 at 11 16 23](https://user-images.githubusercontent.com/903327/37217541-cf2c8284-238b-11e8-91b1-7cafe0467701.png)
