### PR TITLE
Add app-frame component and package

### DIFF
--- a/packages/tbds-app-frame/index.scss
+++ b/packages/tbds-app-frame/index.scss
@@ -1,0 +1,1 @@
+@import "./lib/app-frame.scss";

--- a/packages/tbds-app-frame/lib/app-frame.scss
+++ b/packages/tbds-app-frame/lib/app-frame.scss
@@ -1,0 +1,26 @@
+.app-frame {
+  align-items: stretch;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  width: 100%;
+}
+
+.app-frame__header {
+  flex-grow: 0;
+}
+
+.app-frame__body {
+  flex-grow: 1;
+}
+
+.app-frame__footer {
+  flex-grow: 0;
+}
+
+.app-frame__body--vertical-middle {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}

--- a/packages/tbds-app-frame/package.json
+++ b/packages/tbds-app-frame/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@thoughtbot/tbds-app-frame",
+  "version": "0.0.1",
+  "license": "MIT"
+}


### PR DESCRIPTION
A version of this component is already in-use on the [Bourbon website](https://www.bourbon.io/) and [tbot.io](https://tbot.io/). It avoids this:

![avoids-this](https://user-images.githubusercontent.com/903327/37229613-93717be2-23b2-11e8-97d3-49867edf71ab.png)

Here it is in-action (the footer is always pushed to the bottom of the viewport, if there's extra space):

![2018-03-09 16 00 53](https://user-images.githubusercontent.com/903327/37229788-31f6c2c2-23b3-11e8-8e5b-c6c5cf028848.gif)

---

Example usage markup:

```html
<body class="app-frame">
  <header class="app-frame__header">
    <!-- header content, always at top of viewport -->
  </header>

  <main class="app-frame__body">
    <!-- body content, consumes vertical space between header and footer -->
  </main>

  <footer class="app-frame__footer">
    <!-- footer content, always at bottom of viewport -->
  </footer>
</body>
```