### PR TITLE
Add README documentation to tbds-button

### DIFF
--- a/packages/tbds-button/README.md
+++ b/packages/tbds-button/README.md
@@ -1,0 +1,60 @@
+# tbds Button
+
+## Install
+
+tbds packages are distributed through [npm]. You can install `tbds-button`
+and add it as a dependency to your project's by running this command:
+
+```
+npm install --save @thoughtbot/tbds-button
+```
+
+## Usage
+
+tbds uses [Sass][sass]. You can import a package's styles into your project
+like this:
+
+```scss
+@import "@thoughtbot/tbds-button/index";
+```
+
+## Documentation
+
+### Default button
+
+```html
+<button class="tbds-button" type="button">
+  Button
+</button>
+```
+
+### Disabled button state
+
+```html
+<button class="tbds-button" type="button" disabled>
+  Button
+</button>
+```
+
+### Button with icon on the left
+
+```html
+<button class="tbds-button" type="button">
+  <svg class="tbds-button__icon tbds-button__icon--text-to-right">…</svg>
+
+  Button
+</button>
+```
+
+### Button with icon on the right
+
+```html
+<button class="tbds-button" type="button">
+  Button
+
+  <svg class="tbds-button__icon tbds-button__icon--text-to-left">…</svg>
+</button>
+```
+
+[npm]: https://www.npmjs.com/
+[sass]: http://sass-lang.com/


### PR DESCRIPTION
We do not currently have a documentation site for tbds. Having a readme in each package directory is a quick and easy way to document that package. GitHub.com and npmjs.com also render these readme's, so users can get a high-level understanding of how to use and work with tbds packages when browsing on those platforms.