### PR TITLE
Stylelint: Check if variables start with `tbds-`

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,6 +1,11 @@
 {
   "extends": "@thoughtbot/stylelint-config",
   "rules": {
+    "scss/dollar-variable-pattern": [
+      "tbds-[a-z]+", {
+        "message": "All Sass variables should be prefixed with `tbds-`"
+      }
+    ],
     "selector-class-pattern": [
       "tbds-[a-z]+", {
         "message": "All CSS classes should be prefixed with `tbds-`"

--- a/packages/tbds-utilities/lib/margin.scss
+++ b/packages/tbds-utilities/lib/margin.scss
@@ -1,6 +1,6 @@
 /* stylelint-disable declaration-no-important */
 
-$_margin-properties: (
+$_tbds-margin-properties: (
   "margin-top",
   "margin-right",
   "margin-bottom",
@@ -8,11 +8,11 @@ $_margin-properties: (
 ) !default;
 
 @for $i from 1 through length($tbds-space-values) {
-  $size: #{nth($tbds-space-values, $i)};
-  $scale: #{$i - 1};
+  $tbds-size: #{nth($tbds-space-values, $i)};
+  $tbds-scale: #{$i - 1};
 
   @for $property from 1 through length($_margin-properties) {
-    $property: #{nth($_margin-properties, $property)};
+    $tbds-property: #{nth($_margin-properties, $property)};
 
     .tbds-#{$property}-#{$scale} {
       #{$property}: $size !important;

--- a/packages/tbds-utilities/lib/padding.scss
+++ b/packages/tbds-utilities/lib/padding.scss
@@ -1,6 +1,6 @@
 /* stylelint-disable declaration-no-important */
 
-$_padding-properties: (
+$_tbds-padding-properties: (
   "padding-top",
   "padding-right",
   "padding-bottom",
@@ -8,11 +8,11 @@ $_padding-properties: (
 ) !default;
 
 @for $i from 1 through length($tbds-space-values) {
-  $size: #{nth($tbds-space-values, $i)};
-  $scale: #{$i - 1};
+  $tbds-size: #{nth($tbds-space-values, $i)};
+  $tbds-scale: #{$i - 1};
 
   @for $property from 1 through length($_padding-properties) {
-    $property: #{nth($_padding-properties, $property)};
+    $tbds-property: #{nth($_padding-properties, $property)};
 
     .tbds-#{$property}-#{$scale} {
       #{$property}: $size !important;


### PR DESCRIPTION
As we do with classes (see [this commit]), this adds a linter to make
sure all of our Sass variables start with `tbds-`, too.

[this commit]: https://github.com/thoughtbot/design-system/commit/e1f54845cfe869642e835fd184cbd8a3501bb1dc