### PR TITLE
Stylelint: Require `!default` flag for variables

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -6,6 +6,11 @@
         "message": "All Sass variables should be prefixed with `tbds-`"
       }
     ],
+    "scss/dollar-variable-default": [
+      true, {
+        "ignore": "local"
+      }
+    ],
     "selector-class-pattern": [
       "tbds-[a-z]+", {
         "message": "All CSS classes should be prefixed with `tbds-`"


### PR DESCRIPTION
Because our design system is meant to be brought in as a library, we
define our Sass variables with a `!default` flag, so that they can be
overwritten if needed.

https://github.com/kristerkari/stylelint-scss/blob/master/src/rules/dollar-variable-default/README.md