### PR TITLE
Update brand blue

### DIFF
--- a/src/forms/lib/form.scss
+++ b/src/forms/lib/form.scss
@@ -29,8 +29,8 @@
   width: 100%;
 
   &:focus {
-    border-color: $tbds-blue;
-    box-shadow: 0 0 0 1px $tbds-blue;
+    border-color: $tbds-brand-blue;
+    box-shadow: 0 0 0 1px $tbds-brand-blue;
     outline: none;
   }
 }
@@ -49,8 +49,8 @@
   width: 100%;
 
   &:focus {
-    border-color: $tbds-blue;
-    box-shadow: 0 0 0 1px $tbds-blue;
+    border-color: $tbds-brand-blue;
+    box-shadow: 0 0 0 1px $tbds-brand-blue;
     outline: none;
   }
 }

--- a/src/settings/lib/color-palette.scss
+++ b/src/settings/lib/color-palette.scss
@@ -1,4 +1,3 @@
 $tbds-brand-red: #e03131 !default;
 $tbds-brand-gray: #29292c !default;
-
-$tbds-blue: #1568c1 !default;
+$tbds-brand-blue: #0b758c !default;


### PR DESCRIPTION
We based our brand colors off of the press kit, which doesn't have a
defined blue: https://presskit.thoughtbot.com/

There's some thoughtbot.com redesign efforts happening and the team
formalized a blue within the brand color system. You can find this work
in Abstract.

![image](https://user-images.githubusercontent.com/903327/56462364-41afee00-6390-11e9-93e4-f303e582ce4c.png)
