### PR TITLE
Add global variables for styling focus outlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased (`master`)][unreleased]
 
-Nothing at the moment.
+### Added
+
+- Global variables for styling focus outlines
 
 [unreleased]: https://github.com/thoughtbot/design-system/compare/v0.1.0...HEAD
 

--- a/src/button/lib/button.scss
+++ b/src/button/lib/button.scss
@@ -33,6 +33,11 @@ $_tbds-button-text-color-hover: #fff !default;
     color: $_tbds-button-text-color-hover;
   }
 
+  &:focus {
+    box-shadow: 0 0 0 2px #fff, 0 0 0 4px $tbds-focus-outline-color;
+    outline: none;
+  }
+
   &:disabled {
     cursor: not-allowed;
     opacity: 0.5;

--- a/src/elements/lib/typography.scss
+++ b/src/elements/lib/typography.scss
@@ -19,6 +19,11 @@ a {
   &:hover {
     color: $tbds-color-text-link-hover;
   }
+
+  &:focus {
+    outline: $tbds-focus-outline;
+    outline-offset: $tbds-focus-outline-offset;
+  }
 }
 
 b,

--- a/src/settings/index.scss
+++ b/src/settings/index.scss
@@ -1,3 +1,4 @@
 @import "./lib/color";
+@import "./lib/focus";
 @import "./lib/layout";
 @import "./lib/typography";

--- a/src/settings/lib/focus.scss
+++ b/src/settings/lib/focus.scss
@@ -1,0 +1,4 @@
+$tbds-focus-outline-color: $tbds-brand-blue !default;
+$tbds-focus-outline-width: 2px !default;
+$tbds-focus-outline: $tbds-focus-outline-width solid $tbds-focus-outline-color !default;
+$tbds-focus-outline-offset: 2px !default;


### PR DESCRIPTION
This adds global variables for styling focus outlines, and uses the
variables to style focus styles on links and buttons.

Visual focus outlines are important for accessibility. They identify
where the active focus is when using devices other than a mouse or
touch input.

## Before

![Artboard](https://user-images.githubusercontent.com/903327/56850319-0d2bbd00-68cf-11e9-8a8c-eb5c92ee52ba.jpg)

## After

_Note: The change in color is from https://github.com/thoughtbot/design-system/pull/82_

![Artboard Copy](https://user-images.githubusercontent.com/903327/56850305-e53c5980-68ce-11e9-8ba8-c10f8cd94b54.jpg)
