### PR TITLE
Use logical properties and values

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,6 +1,10 @@
 {
   "extends": "@thoughtbot/stylelint-config",
+  "plugins": [
+    "stylelint-use-logical"
+  ],
   "rules": {
+    "csstools/use-logical": "always",
     "scss/at-function-pattern": [
       "tbds-[a-z]+", {
         "message": "All Sass functions should be prefixed with `tbds-`"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ project adheres to [Semantic Versioning](http://semver.org).
 - Added breakpoint variants for the `margin`, `padding`, and `text-align`
   utility classes, e.g. `tbds-margin-right-4@medium`
   and `tbds-text-align-right@large`.
-- Added `width` utility classes (e.g. `tbds-width-25%`) for the
-  following lengths:
+- Added `inline-size` (`width`) utility classes (e.g. `tbds-inline-size-25%`)
+  for the following lengths:
 
     - `20%`
     - `25%`
@@ -25,12 +25,37 @@ project adheres to [Semantic Versioning](http://semver.org).
     - `80%`
     - `100%`
 
-    Breakpoint-based variants are also available (e.g. `tbds-width-25%@medium`).
+    Breakpoint-based variants are also available
+    (e.g. `tbds-inline-size-25%@medium`).
+
+- Added utility classes for margin and padding block & inline shorthands:
+
+    - `tbds-margin-block-*`
+    - `tbds-margin-inline-*`
+    - `tbds-padding-block-*`
+    - `tbds-padding-inline-*`
 
 ### Changed
 
 - `tbds-app-frame__body--vertical-middle` was renamed to
   `tbds-app-frame__body--center-items`
+- Layout properties and values now use logical dimensions instead of physical
+  dimensions, for example `width` is now `inline-size` and `height` is now
+  `block-size`. The following classes were updated to match the new syntax:
+
+    - `tbds-text-align-left` is now `tbds-text-align-start`
+    - `tbds-text-align-right` is now `tbds-text-align-end`
+    - `tbds-margin-top-*` is now `tbds-margin-block-start-*`
+    - `tbds-margin-right-*` is now `tbds-margin-inline-end-*`
+    - `tbds-margin-bottom-*` is now `tbds-margin-block-end-*`
+    - `tbds-margin-left-*` is now `tbds-margin-inline-start-*`
+    - `tbds-padding-top-*` is now `tbds-padding-block-start-*`
+    - `tbds-padding-right-*` is now `tbds-padding-inline-end-*`
+    - `tbds-padding-bottom-*` is now `tbds-padding-block-end-*`
+    - `tbds-padding-left-*` is now `tbds-padding-inline-start-*`
+    - `tbds-button__icon--text-to-left` is now `tbds-button__icon--end`
+    - `tbds-button__icon--text-to-right` is now `tbds-button__icon--start`
+    - `tbds-media--vertical-center` is now `tbds-media tbds-media--block-center`
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3120,6 +3120,12 @@
         }
       }
     },
+    "stylelint-use-logical": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stylelint-use-logical/-/stylelint-use-logical-1.1.0.tgz",
+      "integrity": "sha512-WwYAEoUNXxu4A9tZ+mPnvFSf3wKG9mY9+ZqnNjVHikfOQA4MTO6XeSC8BGCsY7LOG0GnDfmxMrRUJXFZRtaCmg==",
+      "dev": true
+    },
     "sugarss": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "author": "thoughtbot, inc.",
   "devDependencies": {
     "@thoughtbot/stylelint-config": "^1.0.1",
-    "stylelint": "^10.1.0"
+    "stylelint": "^10.1.0",
+    "stylelint-use-logical": "^1.1.0"
   },
   "license": "MIT",
   "name": "@thoughtbot/design-system",

--- a/src/app-frame/lib/app-frame.scss
+++ b/src/app-frame/lib/app-frame.scss
@@ -2,8 +2,8 @@
   align-items: stretch;
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
-  width: 100%;
+  inline-size: 100%;
+  min-block-size: 100vh;
 }
 
 .tbds-app-frame__header {

--- a/src/avatar/lib/avatar.scss
+++ b/src/avatar/lib/avatar.scss
@@ -2,11 +2,11 @@
   --border-radius: 3px;
   --size: 3rem;
 
+  block-size: var(--size);
   border-radius: var(--border-radius);
   display: inline-block;
-  height: var(--size);
+  inline-size: var(--size);
   object-fit: cover;
-  width: var(--size);
 }
 
 .tbds-avatar--circle {

--- a/src/button/README.md
+++ b/src/button/README.md
@@ -22,22 +22,22 @@
 </button>
 ```
 
-### Button with icon on the left
+### Button with icon at the start
 
 ```html
 <button class="tbds-button" type="button">
-  <svg class="tbds-button__icon tbds-button__icon--text-to-right">…</svg>
+  <svg class="tbds-button__icon tbds-button__icon--start">…</svg>
 
   Button
 </button>
 ```
 
-### Button with icon on the right
+### Button with icon at the end
 
 ```html
 <button class="tbds-button" type="button">
   Button
 
-  <svg class="tbds-button__icon tbds-button__icon--text-to-left">…</svg>
+  <svg class="tbds-button__icon tbds-button__icon--end">…</svg>
 </button>
 ```

--- a/src/button/lib/button.scss
+++ b/src/button/lib/button.scss
@@ -51,19 +51,19 @@ $_tbds-button-text-color-hover: #fff !default;
 }
 
 .tbds-button--full-width {
-  width: 100%;
+  inline-size: 100%;
 }
 
 .tbds-button__icon {
+  block-size: 1em;
   fill: currentColor;
-  height: 1em;
-  width: 1em;
+  inline-size: 1em;
 }
 
-.tbds-button__icon--text-to-left {
-  margin-left: 0.5em;
+.tbds-button__icon--start {
+  margin-inline-end: 0.5em;
 }
 
-.tbds-button__icon--text-to-right {
-  margin-right: 0.5em;
+.tbds-button__icon--end {
+  margin-inline-start: 0.5em;
 }

--- a/src/elements/lib/layout.scss
+++ b/src/elements/lib/layout.scss
@@ -9,5 +9,5 @@ html {
 }
 
 img {
-  max-width: 100%;
+  max-inline-size: 100%;
 }

--- a/src/forms/lib/form.scss
+++ b/src/forms/lib/form.scss
@@ -1,7 +1,7 @@
 .tbds-form__label {
   display: block;
   font-weight: $tbds-font-weight-bold;
-  margin-bottom: 0.5rem;
+  margin-block-end: 0.5rem;
 }
 
 .tbds-form__help-text {
@@ -11,7 +11,7 @@
 
 .tbds-form__help-text--block {
   display: block;
-  margin-top: 0.3rem;
+  margin-block-start: 0.3rem;
 }
 
 .tbds-form__text-input {
@@ -20,9 +20,13 @@
   border: 1px solid #888;
   border-radius: 4px;
   font-size: 16px;
+  inline-size: 100%;
   margin: 0;
   padding: 0.5rem 0.8rem;
-  width: 100%;
+
+  @supports (padding-inline: 0) {
+    padding-inline: 0.5rem;
+  }
 
   &:focus {
     border-color: $tbds-brand-blue;
@@ -37,12 +41,16 @@
   border: 1px solid #888;
   border-radius: 4px;
   font-size: 16px;
+  inline-size: 100%;
   line-height: 1.4;
   margin: 0;
-  min-height: 2.25rem;
+  min-block-size: 2.25rem;
   padding: 0.5rem 0.8rem;
   resize: vertical;
-  width: 100%;
+
+  @supports (resize: block) {
+    resize: block;
+  }
 
   &:focus {
     border-color: $tbds-brand-blue;
@@ -57,7 +65,7 @@
 }
 
 .tbds-form__choice + .tbds-form__choice {
-  margin-top: 1rem;
+  margin-block-start: 1rem;
 }
 
 .tbds-form__choice--inline {
@@ -65,10 +73,10 @@
 }
 
 .tbds-form__choice--inline + .tbds-form__choice--inline {
-  margin-left: 1rem;
-  margin-top: 0;
+  margin-block-start: 0;
+  margin-inline-start: 1rem;
 }
 
 .tbds-form__choice-input {
-  margin-right: 0.75rem;
+  margin-inline-end: 0.75rem;
 }

--- a/src/forms/lib/input-button-unit.scss
+++ b/src/forms/lib/input-button-unit.scss
@@ -4,13 +4,23 @@
 
 .tbds-input-button-unit__input {
   border-bottom-right-radius: 0;
-  border-right: none;
+  border-inline-end: none;
   border-top-right-radius: 0;
   flex: 1 1 auto;
   margin: 0;
+
+  @supports (border-end-end-radius: 0) {
+    border-end-end-radius: 0;
+    border-start-end-radius: 0;
+  }
 }
 
 .tbds-input-button-unit__button {
   border-bottom-left-radius: 0;
   border-top-left-radius: 0;
+
+  @supports (border-start-start-radius: 0) {
+    border-end-start-radius: 0;
+    border-start-start-radius: 0;
+  }
 }

--- a/src/forms/lib/reset.scss
+++ b/src/forms/lib/reset.scss
@@ -6,5 +6,5 @@ fieldset {
 
 select {
   font-size: 16px;
-  width: 100%;
+  inline-size: 100%;
 }

--- a/src/icon/lib/icon.scss
+++ b/src/icon/lib/icon.scss
@@ -1,8 +1,8 @@
 .tbds-icon {
   --size: 1em;
 
+  block-size: var(--size);
   fill: currentColor;
-  height: var(--size);
 }
 
 .tbds-icon--large {

--- a/src/media/README.md
+++ b/src/media/README.md
@@ -20,10 +20,10 @@
 </div>
 ```
 
-### Vertically-centered
+### Block-centered
 
 ```html
-<div class="tbds-media tbds-media--vertical-center">
+<div class="tbds-media tbds-media--block-center">
   <div class="tbds-media__figure">
     <img src="image.jpg" alt="alternative text">
   </div>

--- a/src/media/lib/media.scss
+++ b/src/media/lib/media.scss
@@ -3,12 +3,12 @@
   display: flex;
 }
 
-.tbds-media--vertical-center {
+.tbds-media--block-center {
   align-items: center;
 }
 
 .tbds-media__figure {
-  margin-right: $tbds-space-2;
+  margin-inline-end: $tbds-space-2;
 }
 
 .tbds-media__body {

--- a/src/stack/lib/block-stack.scss
+++ b/src/stack/lib/block-stack.scss
@@ -29,12 +29,12 @@ $_tbds-block-stack-border: 1px solid #bbb !default;
 }
 
 .tbds-block-stack__item:not(:last-child) {
-  margin-bottom: calc(var(--gap) / 2);
-  padding-bottom: calc(var(--gap) / 2);
+  margin-block-end: calc(var(--gap) / 2);
+  padding-block-end: calc(var(--gap) / 2);
 }
 
 .tbds-block-stack--bordered {
   .tbds-block-stack__item:not(:last-child) {
-    border-bottom: $_tbds-block-stack-border;
+    border-block-end: $_tbds-block-stack-border;
   }
 }

--- a/src/stack/lib/inline-stack.scss
+++ b/src/stack/lib/inline-stack.scss
@@ -30,10 +30,10 @@
 }
 
 .tbds-inline-stack__item:not(:last-child) {
-  margin-right: calc(var(--gap) / 2);
-  padding-right: calc(var(--gap) / 2);
+  margin-inline-end: calc(var(--gap) / 2);
+  padding-inline-end: calc(var(--gap) / 2);
 }
 
 .tbds-inline-stack__item--push-start {
-  margin-left: auto;
+  margin-inline-start: auto;
 }

--- a/src/utilities/README.md
+++ b/src/utilities/README.md
@@ -7,13 +7,15 @@
 Margin utilities are based on the global spacing scale and available
 for each of these margin properties:
 
-- `margin-top`
-- `margin-right`
-- `margin-bottom`
-- `margin-left`
+- `margin-block-start`
+- `margin-inline-end`
+- `margin-block-end`
+- `margin-inline-start`
+- `margin-block`
+- `margin-inline`
 
 ```html
-<div class="tbds-margin-top-2">
+<div class="tbds-margin-block-start-2">
   Some content
 </div>
 ```
@@ -25,7 +27,7 @@ Each variant's styles are applied at the breakpoint and up (using a
 `min-width` media query).
 
 ```html
-<div class="tbds-margin-right-4@medium">
+<div class="tbds-margin-inline-end-4@medium">
   Some content
 </div>
 ```
@@ -35,13 +37,15 @@ Each variant's styles are applied at the breakpoint and up (using a
 Padding utilities are based on the global spacing scale and available
 for each of these padding properties:
 
-- `padding-top`
-- `padding-right`
-- `padding-bottom`
-- `padding-left`
+- `padding-block-start`
+- `padding-inline-end`
+- `padding-block-end`
+- `padding-inline-start`
+- `padding-block`
+- `padding-inline`
 
 ```html
-<div class="tbds-padding-bottom-1">
+<div class="tbds-padding-block-end-1">
   Some content
 </div>
 ```
@@ -53,15 +57,15 @@ Each variant's styles are applied at the breakpoint and up (using a
 `min-width` media query).
 
 ```html
-<div class="tbds-padding-bottom-1@small">
+<div class="tbds-padding-block-end-1@small">
   Some content
 </div>
 ```
 
-### Width
+### Inline size utilities
 
-Width utilities can be used to set the `width` on element, and are available
-with the following values (quarters, thirds, and fifths):
+Inline size utilities can be used to set the `inline-size` on element, and are
+available with the following values (quarters, thirds, and fifths):
 
 - `20%`
 - `25%`
@@ -75,19 +79,19 @@ with the following values (quarters, thirds, and fifths):
 - `100%`
 
 ```html
-<div class="tbds-width-25%">
+<div class="tbds-inline-size-25%">
   Some content
 </div>
 ```
 
 #### Breakpoint variants
 
-Width utilities can also be used to set `width` at specific breakpoints.
-Each variant's styles are applied at the breakpoint and up (using a
-`min-width` media query).
+Inline size utilities can also be used to set `inline-size` at specific
+breakpoints. Each variant's styles are applied at the breakpoint and up (using
+a `min-width` media query).
 
 ```html
-<div class="tbds-width-50%@medium">
+<div class="tbds-inline-size-50%@medium">
   Some content
 </div>
 ```
@@ -123,14 +127,14 @@ Each variant's styles are applied at the breakpoint and up (using a
 ### Text align
 
 ```html
-<p class="tbds-text-align-right">
-  Right-align text
+<p class="tbds-text-align-end">
+  Align text to the end of the content flow
 </p>
 ```
 
 ```html
-<p class="tbds-text-align-left">
-  Left-align text
+<p class="tbds-text-align-start">
+  Align text to the start of the content flow
 </p>
 ```
 

--- a/src/utilities/index.scss
+++ b/src/utilities/index.scss
@@ -2,8 +2,8 @@
 
 @import "./lib/font-style";
 @import "./lib/font-weight";
+@import "./lib/inline-size";
 @import "./lib/line-height";
 @import "./lib/margin";
 @import "./lib/padding";
 @import "./lib/text-align";
-@import "./lib/width";

--- a/src/utilities/lib/inline-size.scss
+++ b/src/utilities/lib/inline-size.scss
@@ -1,4 +1,4 @@
-$tbds-width-lengths: (
+$tbds-inline-size-lengths: (
   20%,
   25%,
   33.3333%,
@@ -11,11 +11,11 @@ $tbds-width-lengths: (
   100%,
 ) !default;
 
-@each $length in $tbds-width-lengths {
+@each $length in $tbds-inline-size-lengths {
   $percent-sign: \0025;
 
   @include tbds-generate-breakpoint-classes(
-    $property: "width",
+    $property: "inline-size",
     $value: $length,
     $variant: round(tbds-strip-unit($length)) + $percent-sign,
   );

--- a/src/utilities/lib/margin.scss
+++ b/src/utilities/lib/margin.scss
@@ -1,8 +1,10 @@
 $_tbds-margin-properties: (
-  "margin-top",
-  "margin-right",
-  "margin-bottom",
-  "margin-left",
+  "margin-block",
+  "margin-block-end",
+  "margin-block-start",
+  "margin-inline",
+  "margin-inline-end",
+  "margin-inline-start",
 ) !default;
 
 @each $margin-property in $_tbds-margin-properties {

--- a/src/utilities/lib/padding.scss
+++ b/src/utilities/lib/padding.scss
@@ -1,8 +1,10 @@
 $_tbds-padding-properties: (
-  "padding-top",
-  "padding-right",
-  "padding-bottom",
-  "padding-left",
+  "padding-block",
+  "padding-block-end",
+  "padding-block-start",
+  "padding-inline",
+  "padding-inline-end",
+  "padding-inline-start",
 ) !default;
 
 @each $padding-property in $_tbds-padding-properties {

--- a/src/utilities/lib/text-align.scss
+++ b/src/utilities/lib/text-align.scss
@@ -1,7 +1,7 @@
 $_tbds-text-align-values: (
-  "left",
+  "start",
   "center",
-  "right",
+  "end",
 ) !default;
 
 @each $text-align-value in $_tbds-text-align-values {


### PR DESCRIPTION
Physical dimensions and directions are described left to right and top
to bottom, while their logical counterparts are described start to end
and inline or block. Logical properties and values are
writing-mode _relative_.

From [the spec](https://drafts.csswg.org/css-logical/):

> Because different writing systems are written in different directions,
> a variety of writing modes exist: left to right, top to bottom; right
> to left, top to bottom; bottom to top, right to left; etc. logical
> concepts like the “start” of a page or line map differently to
> physical concepts like the “top” of a line or “left edge” of a
> paragraph. Some aspects of a layout are actually relative to the
> writing directions, and thus will vary when the page is translated
> to a different system; others are inherently relative to the page’s
> physical orientation.

Current browser support: https://caniuse.com/#feat=css-logical-props

Some of these properties and values are still experimental, like
`margin-block`, so we use an `@supports` feature query to test for
browser support.

Closes: https://github.com/thoughtbot/design-system/issues/96