### PR TITLE
Fix vertical alignment of button icons

### DIFF
--- a/src/button/lib/button.scss
+++ b/src/button/lib/button.scss
@@ -58,6 +58,7 @@ $_tbds-button-text-color-hover: #fff !default;
   fill: currentColor;
   height: 1em;
   width: 1em;
+  vertical-align: middle;
 }
 
 .tbds-button__icon--text-to-left {

--- a/src/button/lib/button.scss
+++ b/src/button/lib/button.scss
@@ -57,8 +57,8 @@ $_tbds-button-text-color-hover: #fff !default;
 .tbds-button__icon {
   fill: currentColor;
   height: 1em;
-  width: 1em;
   vertical-align: middle;
+  width: 1em;
 }
 
 .tbds-button__icon--text-to-left {


### PR DESCRIPTION
Fixed #95

Added `.vertical-align: middle`

**Before**

<img width="406" alt="Screen Shot 2019-06-01 at 3 20 28 PM" src="https://user-images.githubusercontent.com/12416227/58752675-29e48300-8481-11e9-8633-7f5a9c8097ba.png">

**After**

<img width="401" alt="Screen Shot 2019-06-01 at 3 20 47 PM" src="https://user-images.githubusercontent.com/12416227/58752678-454f8e00-8481-11e9-9045-fc1d98a479ab.png">



