### PR TITLE
Rename app-frame modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ project adheres to [Semantic Versioning](http://semver.org).
 
 - Added the `tbds-line-height-0` utility class.
 
+### Changed
+
+- `tbds-app-frame__body--vertical-middle` was renamed to
+  `tbds-app-frame__body--center-items`
+
 [unreleased]: https://github.com/thoughtbot/design-system/compare/v0.2.0...HEAD
 
 ## [0.2.0] - 2019-05-10

--- a/src/app-frame/lib/app-frame.scss
+++ b/src/app-frame/lib/app-frame.scss
@@ -14,7 +14,7 @@
   flex-grow: 1;
 }
 
-.tbds-app-frame__body--vertical-middle {
+.tbds-app-frame__body--center-items {
   align-items: center;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
This modifier class centered content in both axes, so `vertical-middle`
doesn't make the most sense.