### PR TITLE
Breakpoint-based utility classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ project adheres to [Semantic Versioning](http://semver.org).
 ### Added
 
 - Added the `tbds-line-height-0` utility class.
+- Added breakpoint variants for the `margin`, `padding`, and `text-align`
+  utility classes, e.g. `tbds-margin-right-4@medium`
+  and `tbds-text-align-right@large`.
 
 ### Changed
 

--- a/src/settings/index.scss
+++ b/src/settings/index.scss
@@ -3,3 +3,5 @@
 @import "./lib/focus";
 @import "./lib/layout";
 @import "./lib/typography";
+
+@import "./tools/generate-breakpoint-classes";

--- a/src/settings/lib/layout.scss
+++ b/src/settings/lib/layout.scss
@@ -1,19 +1,19 @@
 $tbds-base-space-value: 8px !default;
 
 $tbds-space-values: (
-  0,
-  $tbds-base-space-value / 2,
-  $tbds-base-space-value,
-  $tbds-base-space-value * 2,
-  $tbds-base-space-value * 3,
-  $tbds-base-space-value * 4,
-  $tbds-base-space-value * 5,
+  "0": 0,
+  "1": $tbds-base-space-value / 2,
+  "2": $tbds-base-space-value,
+  "3": $tbds-base-space-value * 2,
+  "4": $tbds-base-space-value * 3,
+  "5": $tbds-base-space-value * 4,
+  "6": $tbds-base-space-value * 5,
 ) !default;
 
-$tbds-space-0: nth($tbds-space-values, 1) !default;
-$tbds-space-1: nth($tbds-space-values, 2) !default;
-$tbds-space-2: nth($tbds-space-values, 3) !default;
-$tbds-space-3: nth($tbds-space-values, 4) !default;
-$tbds-space-4: nth($tbds-space-values, 5) !default;
-$tbds-space-5: nth($tbds-space-values, 6) !default;
-$tbds-space-6: nth($tbds-space-values, 7) !default;
+$tbds-space-0: map-get($tbds-space-values, "0") !default;
+$tbds-space-1: map-get($tbds-space-values, "1") !default;
+$tbds-space-2: map-get($tbds-space-values, "2") !default;
+$tbds-space-3: map-get($tbds-space-values, "3") !default;
+$tbds-space-4: map-get($tbds-space-values, "4") !default;
+$tbds-space-5: map-get($tbds-space-values, "5") !default;
+$tbds-space-6: map-get($tbds-space-values, "6") !default;

--- a/src/settings/tools/generate-breakpoint-classes.scss
+++ b/src/settings/tools/generate-breakpoint-classes.scss
@@ -1,0 +1,21 @@
+/* stylelint-disable declaration-no-important */
+
+@mixin tbds-generate-breakpoint-classes(
+  $property,
+  $value,
+  $variant,
+) {
+  .tbds-#{$property}-#{$variant} {
+    #{$property}: unquote(#{$value}) !important;
+  }
+
+  @each $breakpoint, $breakpoint-value in $tbds-breakpoints {
+    @media (min-width: $breakpoint-value) {
+      .tbds-#{$property}-#{$variant}\@#{$breakpoint} {
+        #{$property}: unquote(#{$value}) !important;
+      }
+    }
+  }
+}
+
+/* stylelint-enable */

--- a/src/utilities/README.md
+++ b/src/utilities/README.md
@@ -10,10 +10,34 @@
 </div>
 ```
 
+#### Breakpoint variants
+
+Margin utilities can also be used to set `margin` at specific breakpoints.
+Each variant's styles are applied at the breakpoint and up (using a
+`min-width` media query).
+
+```html
+<div class="tbds-margin-right-4@medium">
+  Some content
+</div>
+```
+
 ### Padding utilities
 
 ```html
 <div class="tbds-padding-bottom-1">
+  Some content
+</div>
+```
+
+#### Breakpoint variants
+
+Padding utilities can also be used to set `padding` at specific breakpoints.
+Each variant's styles are applied at the breakpoint and up (using a
+`min-width` media query).
+
+```html
+<div class="tbds-padding-bottom-1@small">
   Some content
 </div>
 ```
@@ -60,6 +84,18 @@
 <p class="tbds-text-align-center">
   Center-align text
 </p>
+```
+
+#### Breakpoint variants
+
+Typography utilities can also be used to set styles at specific breakpoints.
+Each variant's styles are applied at the breakpoint and up (using a
+`min-width` media query).
+
+```html
+<div class="tbds-text-align-right@large">
+  Some content
+</div>
 ```
 
 ### Line height utilities

--- a/src/utilities/lib/margin.scss
+++ b/src/utilities/lib/margin.scss
@@ -5,16 +5,12 @@ $_tbds-margin-properties: (
   "margin-left",
 ) !default;
 
-@for $i from 1 through length($tbds-space-values) {
-  $size: #{nth($tbds-space-values, $i)};
-  $scale: #{$i - 1};
-
-  @for $property from 1 through length($_tbds-margin-properties) {
-    $property: #{nth($_tbds-margin-properties, $property)};
-
-    .tbds-#{$property}-#{$scale} {
-      /* stylelint-disable-next-line declaration-no-important */
-      #{$property}: $size !important;
-    }
+@each $margin-property in $_tbds-margin-properties {
+  @each $space-increment, $space-value in $tbds-space-values {
+    @include tbds-generate-breakpoint-classes(
+      $property: $margin-property,
+      $value: $space-value,
+      $variant: $space-increment,
+    );
   }
 }

--- a/src/utilities/lib/padding.scss
+++ b/src/utilities/lib/padding.scss
@@ -5,16 +5,12 @@ $_tbds-padding-properties: (
   "padding-left",
 ) !default;
 
-@for $i from 1 through length($tbds-space-values) {
-  $size: #{nth($tbds-space-values, $i)};
-  $scale: #{$i - 1};
-
-  @for $property from 1 through length($_tbds-padding-properties) {
-    $property: #{nth($_tbds-padding-properties, $property)};
-
-    .tbds-#{$property}-#{$scale} {
-      /* stylelint-disable-next-line declaration-no-important */
-      #{$property}: $size !important;
-    }
+@each $padding-property in $_tbds-padding-properties {
+  @each $space-increment, $space-value in $tbds-space-values {
+    @include tbds-generate-breakpoint-classes(
+      $property: $padding-property,
+      $value: $space-value,
+      $variant: $space-increment,
+    );
   }
 }

--- a/src/utilities/lib/text-align.scss
+++ b/src/utilities/lib/text-align.scss
@@ -1,14 +1,13 @@
-.tbds-text-align-right {
-  /* stylelint-disable-next-line declaration-no-important */
-  text-align: right !important;
-}
+$_tbds-text-align-values: (
+  "left",
+  "center",
+  "right",
+) !default;
 
-.tbds-text-align-left {
-  /* stylelint-disable-next-line declaration-no-important */
-  text-align: left !important;
-}
-
-.tbds-text-align-center {
-  /* stylelint-disable-next-line declaration-no-important */
-  text-align: center !important;
+@each $text-align-value in $_tbds-text-align-values {
+  @include tbds-generate-breakpoint-classes(
+    $property: "text-align",
+    $value: $text-align-value,
+    $variant: $text-align-value,
+  );
 }


### PR DESCRIPTION
This allows users to use utility classes to set styles at specific
breakpoints, using a class like `tbds-margin-right-4@medium` where
`medium` is equal to the globally defined `medium` breakpoint.