### PR TITLE
Enable stylelint custom-property-pattern rule

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -5,6 +5,11 @@
   ],
   "rules": {
     "csstools/use-logical": "always",
+    "custom-property-pattern": [
+      "tbds-[a-z]+", {
+        "message": "All CSS custom properties should be prefixed with `tbds-`"
+      }
+    ],
     "scss/at-function-pattern": [
       "tbds-[a-z]+", {
         "message": "All Sass functions should be prefixed with `tbds-`"


### PR DESCRIPTION
Now that we're using more and more CSS Custom Properties over Sass
variables, we should leverage stylelint to check that they are
namespaced with `tbds-`.

The following patterns are considered violations:

```css
html { --color-text-default: #000; }
```

The following patterns are _not_ considered violations:

```css
html { --tbds-color-text-default: #000; }
```