### PR TITLE
Use Sass silent comments for stylelint disabling

### DIFF
--- a/src/settings/tools/generate-breakpoint-classes.scss
+++ b/src/settings/tools/generate-breakpoint-classes.scss
@@ -1,4 +1,4 @@
-/* stylelint-disable declaration-no-important */
+// stylelint-disable declaration-no-important
 
 @mixin tbds-generate-breakpoint-classes(
   $property,
@@ -18,4 +18,4 @@
   }
 }
 
-/* stylelint-enable */
+// stylelint-enable

--- a/src/utilities/lib/font-style.scss
+++ b/src/utilities/lib/font-style.scss
@@ -1,9 +1,9 @@
 .tbds-font-style-normal {
-  /* stylelint-disable-next-line declaration-no-important */
+  // stylelint-disable-next-line declaration-no-important
   font-style: normal !important;
 }
 
 .tbds-font-style-italic {
-  /* stylelint-disable-next-line declaration-no-important */
+  // stylelint-disable-next-line declaration-no-important
   font-style: italic !important;
 }

--- a/src/utilities/lib/font-weight.scss
+++ b/src/utilities/lib/font-weight.scss
@@ -1,9 +1,9 @@
 .tbds-font-weight-normal {
-  /* stylelint-disable-next-line declaration-no-important */
+  // stylelint-disable-next-line declaration-no-important
   font-weight: $tbds-font-weight-normal !important;
 }
 
 .tbds-font-weight-bold {
-  /* stylelint-disable-next-line declaration-no-important */
+  // stylelint-disable-next-line declaration-no-important
   font-weight: $tbds-font-weight-bold !important;
 }

--- a/src/utilities/lib/line-height.scss
+++ b/src/utilities/lib/line-height.scss
@@ -1,4 +1,4 @@
 .tbds-line-height-0 {
-  /* stylelint-disable-next-line declaration-no-important */
+  // stylelint-disable-next-line declaration-no-important
   line-height: 0 !important;
 }


### PR DESCRIPTION
This prevents these stylelint (which is a tool for development purposes)
comments from reaching the compiled CSS.