### PR TITLE
Rename some custom properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ project adheres to [Semantic Versioning](http://semver.org).
 
 [unreleased]: https://github.com/thoughtbot/design-system/compare/v0.3.0...HEAD
 
+### Changed
+
+- The `--border-radius` custom property in the `tbds-avatar` component was
+  renamed to `--tbds-border-radius`.
+- The `--size` custom property in the `tbds-avatar` component was
+  renamed to `--tbds-size`.
+- The `--size` custom property in the `tbds-icon` component was
+  renamed to `--tbds-icon-size`.
+- The `--gap` custom property in the `tbds-block-stack` component was
+  renamed to `--tbds-block-stack-gap`.
+- The `--gap` custom property in the `tbds-inline-stack` component was
+  renamed to `--tbds-inline-stack-gap`.
+
 ## [0.3.0] - 2019-06-19
 
 ### Added

--- a/src/avatar/lib/avatar.scss
+++ b/src/avatar/lib/avatar.scss
@@ -1,22 +1,22 @@
 .tbds-avatar {
-  --border-radius: 3px;
-  --size: 3rem;
+  --tbds-border-radius: 3px;
+  --tbds-size: 3rem;
 
-  block-size: var(--size);
-  border-radius: var(--border-radius);
+  block-size: var(--tbds-size);
+  border-radius: var(--tbds-border-radius);
   display: inline-block;
-  inline-size: var(--size);
+  inline-size: var(--tbds-size);
   object-fit: cover;
 }
 
 .tbds-avatar--circle {
-  --border-radius: 100%;
+  --tbds-border-radius: 100%;
 }
 
 .tbds-avatar--small {
-  --size: 2rem;
+  --tbds-size: 2rem;
 }
 
 .tbds-avatar--large {
-  --size: 4rem;
+  --tbds-size: 4rem;
 }

--- a/src/icon/lib/icon.scss
+++ b/src/icon/lib/icon.scss
@@ -1,14 +1,14 @@
 .tbds-icon {
-  --size: 1em;
+  --tbds-icon-size: 1em;
 
-  block-size: var(--size);
+  block-size: var(--tbds-icon-size);
   fill: currentColor;
 }
 
 .tbds-icon--large {
-  --size: 1.25em;
+  --tbds-icon-size: 1.25em;
 }
 
 .tbds-icon--small {
-  --size: 0.75em;
+  --tbds-icon-size: 0.75em;
 }

--- a/src/stack/lib/block-stack.scss
+++ b/src/stack/lib/block-stack.scss
@@ -1,36 +1,36 @@
 $_tbds-block-stack-border: 1px solid #bbb !default;
 
 .tbds-block-stack {
-  --gap: #{$tbds-space-2};
+  --tbds-block-stack-gap: #{$tbds-space-2};
 }
 
 .tbds-block-stack--gap-1 {
-  --gap: #{$tbds-space-1};
+  --tbds-block-stack-gap: #{$tbds-space-1};
 }
 
 .tbds-block-stack--gap-2 {
-  --gap: #{$tbds-space-2};
+  --tbds-block-stack-gap: #{$tbds-space-2};
 }
 
 .tbds-block-stack--gap-3 {
-  --gap: #{$tbds-space-3};
+  --tbds-block-stack-gap: #{$tbds-space-3};
 }
 
 .tbds-block-stack--gap-4 {
-  --gap: #{$tbds-space-4};
+  --tbds-block-stack-gap: #{$tbds-space-4};
 }
 
 .tbds-block-stack--gap-5 {
-  --gap: #{$tbds-space-5};
+  --tbds-block-stack-gap: #{$tbds-space-5};
 }
 
 .tbds-block-stack--gap-6 {
-  --gap: #{$tbds-space-6};
+  --tbds-block-stack-gap: #{$tbds-space-6};
 }
 
 .tbds-block-stack__item:not(:last-child) {
-  margin-block-end: calc(var(--gap) / 2);
-  padding-block-end: calc(var(--gap) / 2);
+  margin-block-end: calc(var(--tbds-block-stack-gap) / 2);
+  padding-block-end: calc(var(--tbds-block-stack-gap) / 2);
 }
 
 .tbds-block-stack--bordered {

--- a/src/stack/lib/inline-stack.scss
+++ b/src/stack/lib/inline-stack.scss
@@ -1,37 +1,37 @@
 .tbds-inline-stack {
-  --gap: #{$tbds-space-2};
+  --tbds-inline-stack-gap: #{$tbds-space-2};
 
   align-items: center;
   display: flex;
 }
 
 .tbds-inline-stack--gap-1 {
-  --gap: #{$tbds-space-1};
+  --tbds-inline-stack-gap: #{$tbds-space-1};
 }
 
 .tbds-inline-stack--gap-2 {
-  --gap: #{$tbds-space-2};
+  --tbds-inline-stack-gap: #{$tbds-space-2};
 }
 
 .tbds-inline-stack--gap-3 {
-  --gap: #{$tbds-space-3};
+  --tbds-inline-stack-gap: #{$tbds-space-3};
 }
 
 .tbds-inline-stack--gap-4 {
-  --gap: #{$tbds-space-4};
+  --tbds-inline-stack-gap: #{$tbds-space-4};
 }
 
 .tbds-inline-stack--gap-5 {
-  --gap: #{$tbds-space-5};
+  --tbds-inline-stack-gap: #{$tbds-space-5};
 }
 
 .tbds-inline-stack--gap-6 {
-  --gap: #{$tbds-space-6};
+  --tbds-inline-stack-gap: #{$tbds-space-6};
 }
 
 .tbds-inline-stack__item:not(:last-child) {
-  margin-inline-end: calc(var(--gap) / 2);
-  padding-inline-end: calc(var(--gap) / 2);
+  margin-inline-end: calc(var(--tbds-inline-stack-gap) / 2);
+  padding-inline-end: calc(var(--tbds-inline-stack-gap) / 2);
 }
 
 .tbds-inline-stack__item--push-start {


### PR DESCRIPTION
This fixes two issues:

1. All CSS Custom Properties should be namespaced with `tbds-`; we have
   a stylelint rule checking for this, so this resolves those warnings.
2. When composing `tbds-block-stack` and `tbds-inline-stack` components
   together, both had a CSS Custom Property name `--gap` and so you
   could not have the `gap` set different between those two components.
   Naming them based on their respective components prevents
   this collision.