### PR TITLE
Add `auto` as a margin utility value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ project adheres to [Semantic Versioning](http://semver.org).
 
 - Added `$tbds-control-block-size` to set controls (text inputs and buttons) to
   the same block size.
+- Margin utilities now include `auto` (e.g. `tbds-margin-inline-auto`).
 
 ### Changed
 

--- a/src/utilities/README.md
+++ b/src/utilities/README.md
@@ -32,6 +32,18 @@ Each variant's styles are applied at the breakpoint and up (using a
 </div>
 ```
 
+#### `auto`
+
+The `auto` keyword value is also available as utility classes for the margin
+properties above. Note that breakpoint variants are not supported in
+this context.
+
+```html
+<div class="tbds-margin-inline-auto">
+  Some content
+</div>
+```
+
 ### Padding
 
 Padding utilities are based on the global spacing scale and available

--- a/src/utilities/lib/margin.scss
+++ b/src/utilities/lib/margin.scss
@@ -16,3 +16,10 @@ $_tbds-margin-properties: (
     );
   }
 }
+
+@each $margin-property in $_tbds-margin-properties {
+  .tbds-#{$margin-property}-auto {
+    // stylelint-disable-next-line declaration-no-important
+    #{$margin-property}: auto !important;
+  }
+}


### PR DESCRIPTION
This extends our margin utility classes to also provide the
`auto` value.

The `auto` keyword value for `margin` is commonly used for
inline-centering, or to extend an element's margin to also consume the
extra space in a flex container.

The compiled output of these additions is:

```css
.tbds-margin-block-auto {
  margin-block: auto !important;
}

.tbds-margin-block-end-auto {
  margin-block-end: auto !important;
}

.tbds-margin-block-start-auto {
  margin-block-start: auto !important;
}

.tbds-margin-inline-auto {
  margin-inline: auto !important;
}

.tbds-margin-inline-end-auto {
  margin-inline-end: auto !important;
}

.tbds-margin-inline-start-auto {
  margin-inline-start: auto !important;
}
```