### PR TITLE
Refactor breakpoint class generator mixin

### DIFF
--- a/src/settings/tools/generate-breakpoint-classes.scss
+++ b/src/settings/tools/generate-breakpoint-classes.scss
@@ -1,21 +1,22 @@
-// stylelint-disable declaration-no-important
-
 @mixin tbds-generate-breakpoint-classes(
+  $selector,
   $property,
   $value,
-  $variant,
+  $important: null,
 ) {
-  .tbds-#{$property}-#{$variant} {
-    #{$property}: unquote(#{$value}) !important;
+  @if $important {
+    $important: "!important";
+  }
+
+  .#{$selector} {
+    #{$property}: unquote(#{$value})#{$important};
   }
 
   @each $breakpoint, $breakpoint-value in $tbds-breakpoints {
     @media (min-width: $breakpoint-value) {
-      .tbds-#{$property}-#{$variant}\@#{$breakpoint} {
-        #{$property}: unquote(#{$value}) !important;
+      .#{$selector}\@#{$breakpoint} {
+        #{$property}: unquote(#{$value})#{$important};
       }
     }
   }
 }
-
-// stylelint-enable

--- a/src/utilities/lib/inline-size.scss
+++ b/src/utilities/lib/inline-size.scss
@@ -12,11 +12,13 @@ $tbds-inline-size-lengths: (
 ) !default;
 
 @each $length in $tbds-inline-size-lengths {
+  $rounded-unitless-length: round(tbds-strip-unit($length));
   $percent-sign: \0025;
 
   @include tbds-generate-breakpoint-classes(
+    $selector: "tbds-inline-size-" + $rounded-unitless-length + $percent-sign,
     $property: "inline-size",
     $value: $length,
-    $variant: round(tbds-strip-unit($length)) + $percent-sign,
+    $important: true,
   );
 }

--- a/src/utilities/lib/margin.scss
+++ b/src/utilities/lib/margin.scss
@@ -10,9 +10,10 @@ $_tbds-margin-properties: (
 @each $margin-property in $_tbds-margin-properties {
   @each $space-increment, $space-value in $tbds-space-values {
     @include tbds-generate-breakpoint-classes(
+      $selector: "tbds-" + $margin-property + "-" + $space-increment,
       $property: $margin-property,
       $value: $space-value,
-      $variant: $space-increment,
+      $important: true,
     );
   }
 }

--- a/src/utilities/lib/padding.scss
+++ b/src/utilities/lib/padding.scss
@@ -10,9 +10,10 @@ $_tbds-padding-properties: (
 @each $padding-property in $_tbds-padding-properties {
   @each $space-increment, $space-value in $tbds-space-values {
     @include tbds-generate-breakpoint-classes(
+      $selector: "tbds-" + $padding-property + "-" + $space-increment,
       $property: $padding-property,
       $value: $space-value,
-      $variant: $space-increment,
+      $important: true,
     );
   }
 }

--- a/src/utilities/lib/text-align.scss
+++ b/src/utilities/lib/text-align.scss
@@ -6,8 +6,9 @@ $_tbds-text-align-values: (
 
 @each $text-align-value in $_tbds-text-align-values {
   @include tbds-generate-breakpoint-classes(
+    $selector: "tbds-text-align-" + $text-align-value,
     $property: "text-align",
     $value: $text-align-value,
-    $variant: $text-align-value,
+    $important: true,
   );
 }


### PR DESCRIPTION
This refactors the `tbds-generate-breakpoint-classes` mixin to be more
reusable in two ways:

1. The `!important` rule is now opt-in, making it optional.

    Before, `!important` rules were always placed on declarations output
    by this mixin. This is fine for utilities where we want
    `!important`, but when we want to generate breakpoint classes for
    non-utilities, we were out of luck.

2. It can now generate more complex selectors.

    Before, you passed in a variant (e.g. `start` and `3`) which was
    then appended onto the end of the property we were generating
    rulesets for (e.g. `text-align-[start]` or `margin-block-[3]`). This
    does not account for when you want the variant to be placed in the
    _middle_ of a selector, or another place (e.g. `grid--2-columns`).