### PR TITLE
Invert images in inverted colors mode

### DIFF
--- a/src/elements/index.scss
+++ b/src/elements/index.scss
@@ -1,4 +1,5 @@
 @import "../settings/index";
 
 @import "./lib/layout";
+@import "./lib/media";
 @import "./lib/typography";

--- a/src/elements/lib/layout.scss
+++ b/src/elements/lib/layout.scss
@@ -10,8 +10,4 @@ html {
 
 img {
   max-inline-size: 100%;
-
-  @media (inverted-colors: inverted) {
-    filter: invert(100%);
-  }
 }

--- a/src/elements/lib/layout.scss
+++ b/src/elements/lib/layout.scss
@@ -10,4 +10,8 @@ html {
 
 img {
   max-inline-size: 100%;
+
+  @media (inverted-colors: inverted) {
+    filter: invert(100%);
+  }
 }

--- a/src/elements/lib/media.scss
+++ b/src/elements/lib/media.scss
@@ -1,0 +1,6 @@
+img,
+video {
+  @media (inverted-colors: inverted) {
+    filter: invert(100%);
+  }
+}


### PR DESCRIPTION
This PR adds support for images in inverted colors mode. It mirrors work done in https://github.com/thoughtbot/thoughtbot.com/pull/1880.

The inverted colors mode media query is set in `layout.scss`, allowing all images to inherit it.