### PR TITLE
Link state change

### DIFF
--- a/src/elements/lib/typography.scss
+++ b/src/elements/lib/typography.scss
@@ -18,11 +18,13 @@ a {
 
   &:hover {
     color: $tbds-color-text-link-hover;
+    text-decoration: none;
   }
 
   &:focus {
     outline: $tbds-focus-outline;
     outline-offset: $tbds-focus-outline-offset;
+    text-decoration: none;
   }
 }
 


### PR DESCRIPTION
This PR addresses [a conversation in the Bade component about link states](https://github.com/thoughtbot/design-system/pull/131#discussion_r324820332). It updates the `a` element selector to remove the link underline on `hover` and `focus`. This ensures that state change for links does not rely on color alone.