### PR TITLE
Update brand colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,24 @@ project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased (`master`)][unreleased]
 
-Nothing at the moment.
+### Added
+
+- Added more brand color variables, to match our
+  [Brand Guidelines][brand-guidelines]:
+    - `$tbds-brand-gray-medium`
+    - `$tbds-brand-gray-light`
+    - `$tbds-brand-gray-ultra-light`
+    - `$tbds-brand-purple`
+    - `$tbds-brand-yellow`
+    - `$tbds-brand-yellow-light`
+
+### Changed
+
+- `$tbds-brand-gray` is now `$tbds-brand-gray-dark`.
+- The value of `$tbds-brand-blue` is now `#2e52e4`.
 
 [unreleased]: https://github.com/thoughtbot/design-system/compare/v0.5.0...HEAD
+[brand-guidelines]: https://thoughtbot.com/playbook/our-company/brand/colors
 
 ## [0.5.0] - 2019-09-19
 

--- a/src/badge/lib/badge.scss
+++ b/src/badge/lib/badge.scss
@@ -1,6 +1,6 @@
 $_tbds-badge-font-size: 0.8em !default;
 $_tbds-badge-background-color: #f5f5f5 !default;
-$_tbds-badge-color: $tbds-brand-gray !default;
+$_tbds-badge-color: $tbds-brand-gray-dark !default;
 
 .tbds-badge {
   background-color: $_tbds-badge-background-color;

--- a/src/settings/lib/color-palette.scss
+++ b/src/settings/lib/color-palette.scss
@@ -1,3 +1,9 @@
 $tbds-brand-red: #e03131 !default;
-$tbds-brand-gray: #29292c !default;
-$tbds-brand-blue: #0b758c !default;
+$tbds-brand-gray-dark: #29292c !default;
+$tbds-brand-gray-medium: #3d3e44 !default;
+$tbds-brand-gray-light: #67676e !default;
+$tbds-brand-gray-ultra-light: #f0f0f8 !default;
+$tbds-brand-blue: #2e52e4 !default;
+$tbds-brand-purple: #6931e0 !default;
+$tbds-brand-yellow: #ffc726 !default;
+$tbds-brand-yellow-light: #ffe7a3 !default;

--- a/src/settings/lib/color.scss
+++ b/src/settings/lib/color.scss
@@ -1,5 +1,5 @@
 @import "color-palette";
 
-$tbds-color-text-default: $tbds-brand-gray !default;
+$tbds-color-text-default: $tbds-brand-gray-dark !default;
 $tbds-color-text-link: $tbds-color-text-default !default;
 $tbds-color-text-link-hover: $tbds-brand-red !default;


### PR DESCRIPTION
This updates our brand color variables to match the updates recently
made in our [Brand Guidelines][brand-guidelines].

[brand-guidelines]: https://thoughtbot.com/playbook/our-company/brand/colors