### PR TITLE
Ensure the HTML `hidden` attribute hides content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ project adheres to [Semantic Versioning](http://semver.org).
     - `$tbds-brand-purple`
     - `$tbds-brand-yellow`
     - `$tbds-brand-yellow-light`
+- Added `display: none !important;` to the `[hidden]` attribute selector
+  to ensure that elements using the HTML `hidden` attribute are
+  actually hidden.
 
 ### Changed
 

--- a/src/elements/lib/layout.scss
+++ b/src/elements/lib/layout.scss
@@ -11,3 +11,8 @@ html {
 img {
   max-inline-size: 100%;
 }
+
+[hidden] {
+  // stylelint-disable-next-line declaration-no-important
+  display: none !important;
+}


### PR DESCRIPTION
The HTML `hidden` attribute is, in terms of specificity, very weak.
This commit adds `display: none !important;` to the `[hidden]`
attribute selector to ensure that elements using it are actually hidden.

More info: https://css-tricks.com/the-hidden-attribute-is-visibly-weak/

Closes https://github.com/thoughtbot/design-system/issues/138