### PR TITLE
Update documentation to reflect default branch change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org).
 
-## [Unreleased (`master`)][unreleased]
+## [Unreleased (`main`)][unreleased]
 
 Nothing at the moment.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@
     bin/setup
     ```
 
-1. Create a new branch from `master`
+1. Create a new branch from `main`
 
     ```
     git checkout -b my-branch-name

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,7 +3,7 @@
 This documents how to release a new version of tbds. It’s for
 thoughtbot employees.
 
-1. Make sure you’re on the `master` branch with a clean working directory.
+1. Make sure you’re on the `main` branch with a clean working directory.
 
 1. Update the [changelog][changelog], following the guidelines from
    [keep a changelog][keep-a-changelog]


### PR DESCRIPTION
Updates various documentation files to remove references to the `master` branch, which will no longer be the default branch:

Context: [Migrating thoughtbot Repositories to use Main as default branch](https://thoughtbot.com/blog/making-the-move-master-to-main)

Resolves #194 