### PR TITLE
Fix calculation warnings

### DIFF
--- a/src/settings/lib/layout.scss
+++ b/src/settings/lib/layout.scss
@@ -2,12 +2,12 @@ $tbds-base-space-value: 8px !default;
 
 $tbds-space-values: (
   "0": 0,
-  "1": $tbds-base-space-value / 2,
+  "1": calc($tbds-base-space-value / 2),
   "2": $tbds-base-space-value,
-  "3": $tbds-base-space-value * 2,
-  "4": $tbds-base-space-value * 3,
-  "5": $tbds-base-space-value * 4,
-  "6": $tbds-base-space-value * 5,
+  "3": calc($tbds-base-space-value * 2),
+  "4": calc($tbds-base-space-value * 3),
+  "5": calc($tbds-base-space-value * 4),
+  "6": calc($tbds-base-space-value * 5),
 ) !default;
 
 $tbds-space-0: map-get($tbds-space-values, "0") !default;

--- a/src/settings/tools/strip-unit.scss
+++ b/src/settings/tools/strip-unit.scss
@@ -1,3 +1,3 @@
 @function tbds-strip-unit($value) {
-  @return ($value / ($value * 0 + 1));
+  @return (calc($value / ($value * 0 + 1)));
 }


### PR DESCRIPTION
While working on [Design Dot](https://github.com/thoughtbot/design-dot), I got the following deprecation warning:

```
Deprecation Warning: Using / for division outside of calc() is
deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($tbds-base-space-value, 2) or
calc($tbds-base-space-value / 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

  ╷
5 │   "1": $tbds-base-space-value / 2,
  │        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  ╵
    node_modules/@thoughtbot/design-system/src/settings/lib/layout.scss
5:8  @import
    node_modules/@thoughtbot/design-system/src/settings/index.scss 5:9
@import
    node_modules/@thoughtbot/design-system/src/elements/index.scss 1:9
@import
    design-system/src/index.scss 1:9
@import
    _includes/assets/sass/style.scss 1:9
root stylesheet
```

This PR fixes the occurrences of calculations that I have been able to find. There may be others.

Ref:
- https://sass-lang.com/documentation/breaking-changes/slash-div