### PR TITLE
Fix the thoughtbot logo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ under the terms specified in the [LICENSE] file.
 
 ## About
 
-![thoughtbot](http://presskit.thoughtbot.com/images/thoughtbot-logo-for-readmes.svg)
+![thoughtbot](https://thoughtbot.com/brand_assets/93:44.svg)
 
 thoughtbot/design-system is maintained and funded by thoughtbot, inc.
 The names and logos for thoughtbot are trademarks of thoughtbot, inc.


### PR DESCRIPTION
This commit corrects the link to the thoughtbot logo in the README.