### PR TITLE
Cleanup Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,12 @@
+---
 version: 2
+
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: weekly
-    day: friday
-    time: "08:00"
-    timezone: America/New_York
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: "*stylelint*"
-    versions:
-    - ">= 0"
-  - dependency-name: sass
-    versions:
-    - 1.32.5
-    - 1.32.6
-    - 1.32.7
-    - 1.32.8
-  - dependency-name: lodash
-    versions:
-    - 4.17.20
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: friday
+      time: "08:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 10


### PR DESCRIPTION
This commit removes outdated ignore settings from the Dependabot configuration.

It also starts the configuration with `---` and applies auto-formatting.