### PR TITLE
Update the Dependabot timing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-      day: friday
-      time: "08:00"
-      timezone: America/New_York
+      time: "02:00"
+      timezone: "Etc/UTC"
     open-pull-requests-limit: 10


### PR DESCRIPTION
This commit moves Dependabot checks to earlier in the week and outside working hours (for most team members).